### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/udemy2023/a1b27048-d181-4747-87d7-32068a23a342/3eb2b98a-8e2d-4fc3-96d1-0a2a2b4d3ff3/_apis/work/boardbadge/9c76947b-013c-48df-939e-b078feb10aca)](https://dev.azure.com/udemy2023/a1b27048-d181-4747-87d7-32068a23a342/_boards/board/t/3eb2b98a-8e2d-4fc3-96d1-0a2a2b4d3ff3/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/udemy2023/a1b27048-d181-4747-87d7-32068a23a342/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.